### PR TITLE
Updating favicon url and documentation

### DIFF
--- a/jpolacek-dot-com/public/index.html
+++ b/jpolacek-dot-com/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico?" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION
The favicon wasn't showing up with the custom domain for some reason. The suggestion in [this SO post](https://stackoverflow.com/questions/46163065/github-pages-website-favicon-not-showing) seems to work so let's ship it.